### PR TITLE
Alternate implementation of remote access to HDF5 snapshots

### DIFF
--- a/.github/actions/start-hdfstream/action.yml
+++ b/.github/actions/start-hdfstream/action.yml
@@ -1,0 +1,40 @@
+name: 'Start hdfstream'
+description: 'Start the hdfstream service with a mounted directory'
+inputs:
+  data-dir:
+    description: 'Directory with the files to serve'
+    required: true
+    default: './data/'
+  virtual-prefix:
+    description: 'Virtual directory prefix to use'
+    required: true
+    default: 'Data'
+  image:
+    description: 'Server container image to use'
+    required: true
+    default: ghcr.io/jchelly/hdfstream-api:0.0.10
+runs:
+  using: "composite"
+  steps:
+    - name: Start hdfstream service with tests/data mounted
+      shell: bash
+      run: |
+        docker run -d \
+          --name hdfstream \
+          -p 8080:8080 \
+          -v ${{ inputs.data-dir }}:/opt/hdfstream/data:ro \
+          -e HDFSTREAM_PREFIX=${{ inputs.virtual-prefix }} \
+          ${{ inputs.image }}
+    - name: Wait until hdfstream service is responding
+      shell: bash
+      run: |
+        for i in {1..30}; do
+          status=$(docker inspect --format='{{.State.Health.Status}}' hdfstream)
+          if [ "$status" = "healthy" ]; then
+            echo "Service is ready"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Service did not become healthy in time"
+        exit 1

--- a/.github/actions/stop-hdfstream/action.yml
+++ b/.github/actions/stop-hdfstream/action.yml
@@ -1,0 +1,8 @@
+name: "Stop hdfstream"
+description: "Stop and remove the hdfstream container"
+runs:
+  using: "composite"
+  steps:
+    - name: Stop the hdfstream service
+      shell: bash
+      run: docker rm -f hdfstream

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -18,6 +18,11 @@ jobs:
         os: [ubuntu-latest, windows-2025]
         python-version: ["3.12", "3.13", "3.14"]
         numpy-version: ["2.1.0", "2.5.0"]
+        include:
+          - os: ubuntu-latest
+            test_flags: "--hdfstream-server=http://localhost:8080/hdfstream"
+          - os: windows-2025
+            test_flags: ""
         exclude:
           - python-version: "3.14"
             numpy-version: "2.1.0"
@@ -53,9 +58,18 @@ jobs:
         path: tests/testdata
         key: testdata-${{ needs.fetch-testdata.outputs.testdata-key }}
         enableCrossOsArchive: true
-    - name: Run all tests
+
+    - name: Start hdfstream container to serve test data
+      uses: ./.github/actions/start-hdfstream
+      if: ${{ (matrix.os == 'ubuntu-latest') }}
+      with:
+        data-dir: ./tests/testdata
+        virtual-prefix: testdata
+        image: ghcr.io/jchelly/hdfstream-api:0.0.10
+
+    - name: Run tests
       working-directory: tests
-      run: python -m pytest --ignore=testdata/ --tb=short
+      run: python -m pytest --ignore=testdata/ --tb=short ${{ matrix.test_flags }}
     # Following is temporarily necessary because of the >2.0.0rc1 numpy version
     - name: sanitize artifact name
       if: always()
@@ -68,3 +82,7 @@ jobs:
       with:
         name: ${{ env.TARGET_SANI }}
         path: tests/result*.npy
+
+    - name: Stop hdfstream container
+      uses: ./.github/actions/stop-hdfstream
+      if: ${{ (matrix.os == 'ubuntu-latest') }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -48,6 +48,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install numpy==${{ matrix.numpy-version }}
+        python -m pip install hdfstream
     - name: Build and install pynbody
       run: |
         python -m pip install -v .[tests]

--- a/pynbody/snapshot/__init__.py
+++ b/pynbody/snapshot/__init__.py
@@ -42,7 +42,11 @@ def load(filename, *args, **kwargs) -> SimSnap:
     priority = kwargs.pop('priority', config['snap-class-priority'])
 
     for c in SimSnap.iter_subclasses_with_priority(priority):
-        if c._can_load(filename):
+        if "remote_dir" in kwargs:
+            if hasattr(c, "_can_load_remote") and c._can_load_remote(filename, *args, **kwargs):
+                logger.info("Loading using backend %s" % str(c))
+                return c(filename, *args, **kwargs)
+        elif c._can_load(filename):
             logger.info("Loading using backend %s" % str(c))
             return c(filename, *args, **kwargs)
 

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -532,7 +532,7 @@ class GadgetHDFSnap(SimSnap):
         self._init_unit_information()
         self.__init_family_map()
 
-        take = kwargs.pop("take", None)
+        take = self._get_take_parameter(**kwargs)
         self.partial_load = take is not None
         self.__init_file_map(take)
         self._remove_empty_particle_groups()
@@ -540,6 +540,9 @@ class GadgetHDFSnap(SimSnap):
         self.__infer_mass_dtype()
         self._init_properties()
         self._decorate()
+
+    def _get_take_parameter(self, **kwargs):
+        return kwargs.pop("take", None)
 
     def _have_softening_for_particle_type(self, particle_type):
         attrs = self._get_hdf_parameter_attrs()

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -100,6 +100,12 @@ class _GadgetHdfMultiFileManager:
 
         self._open_files = {}
 
+    def max_buf(self):
+        if self._remote_dir is not None:
+            return (2 << 63) # don't chunk http requests
+        else:
+            return _max_buf
+
     def _open_hdf5(self, filename, *args, **kwargs):
         if self._remote_dir is None:
             return h5py.File(filename, *args, **kwargs)
@@ -397,7 +403,7 @@ class HDFArrayLoader:
     def __init_load_map(self, take = None):
         """ Set up family slice and particle count for loading """
 
-        self._load_control = chunk.LoadControl(self._file_ptype_slice, _max_buf, take) # use HDF groups type instead of family type here
+        self._load_control = chunk.LoadControl(self._file_ptype_slice, self._hdf_files.max_buf(), take) # use HDF groups type instead of family type here
         self._family_slice_to_load = {}
         self._num_particles_to_load = self._load_control.mem_num_particles
 

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -33,6 +33,11 @@ try:
 except ImportError:
     h5py = None
 
+try:
+    import hdfstream
+except ImportError:
+    hdfstream = None
+
 _default_type_map = {}
 for x in family.family_names():
     try:
@@ -78,14 +83,15 @@ class _GadgetHdfMultiFileManager:
     _size_from_hdf5_key = "ParticleIDs"
     _subgroup_name = None
 
-    def __init__(self, filename, mode='r') :
+    def __init__(self, filename, mode='r', remote_dir=None):
         filename = str(filename)
         self._mode = mode
-        if h5py.is_hdf5(filename):
+        self._remote_dir = remote_dir
+        if self._is_hdf5(filename):
             self._filenames = [filename]
             self._numfiles = 1
         else:
-            h1 = h5py.File(self._make_filename_for_cpu(filename, 0), mode)
+            h1 = self._open_hdf5(self._make_filename_for_cpu(filename, 0), mode)
             self._numfiles = self._get_num_files(h1)
             if hasattr(self._numfiles, "__len__"):
                 assert len(self._numfiles) == 1
@@ -93,6 +99,18 @@ class _GadgetHdfMultiFileManager:
             self._filenames = [self._make_filename_for_cpu(filename, i) for i in range(self._numfiles)]
 
         self._open_files = {}
+
+    def _open_hdf5(self, filename, *args, **kwargs):
+        if self._remote_dir is None:
+            return h5py.File(filename, *args, **kwargs)
+        else:
+            return self._remote_dir[filename]
+
+    def _is_hdf5(self, filename, *args, **kwargs):
+        if self._remote_dir is None:
+            return h5py.is_hdf5(filename)
+        else:
+            return self._remote_dir.is_hdf5(filename)
 
     def _get_num_files(self, first_file):
         return first_file[self._nfiles_groupname].attrs[self._nfiles_attrname]
@@ -106,7 +124,7 @@ class _GadgetHdfMultiFileManager:
     def __iter__(self) :
         for i in range(self._numfiles) :
             if i not in self._open_files:
-                self._open_files[i] = h5py.File(self._filenames[i], self._mode)
+                self._open_files[i] = self._open_hdf5(self._filenames[i], self._mode)
                 if self._subgroup_name is not None:
                     self._open_files[i] = self._open_files[i][self._subgroup_name]
 
@@ -514,7 +532,7 @@ class GadgetHDFSnap(SimSnap):
 
     _units_need_hubble_factors = True
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, remote_dir=None, **kwargs):
         """Initialise a Gadget HDF snapshot.
 
         Spanned files are supported. To load a range of files ``snap.0.hdf5``, ``snap.1.hdf5``, ... ``snap.n.hdf5``,
@@ -525,7 +543,7 @@ class GadgetHDFSnap(SimSnap):
 
         self._filename = filename
 
-        self._init_hdf_filemanager(filename)
+        self._init_hdf_filemanager(filename, remote_dir=remote_dir)
 
         self._translate_array_name = namemapper.AdaptiveNameMapper(self._namemapper_config_section,
                                                                    return_all_format_names=True) # required for swift
@@ -582,8 +600,8 @@ class GadgetHDFSnap(SimSnap):
     def _get_hdf_unit_attrs(self):
         return self._hdf_files.get_unit_attrs()
 
-    def _init_hdf_filemanager(self, filename):
-        self._hdf_files = self._multifile_manager_class(filename)
+    def _init_hdf_filemanager(self, filename, **kwargs):
+        self._hdf_files = self._multifile_manager_class(filename, **kwargs)
 
     def __init_loadable_keys(self):
 
@@ -1076,6 +1094,16 @@ class GadgetHDFSnap(SimSnap):
                 warnings.warn(
                     "It looks like you're trying to load HDF5 files, but python's HDF support (h5py module) is missing.", RuntimeWarning)
             return False
+
+    @classmethod
+    def _can_load_remote(cls, f, *args, **kwargs):
+        remote_dir = kwargs.get("remote_dir")
+        if (hdfstream is None) or (remote_dir is None):
+            return False
+        for filename in (f, cls._guess_file_ending(f)):
+            if filename in remote_dir and remote_dir[filename].is_hdf5():
+                return cls._readable_hdf5_test_key in remote_dir[filename]
+        return False
 
     def _init_properties(self):
         atr = self._get_hdf_header_attrs()

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -275,16 +275,21 @@ class _HDFArrayFiller:
 
     def _fill_from_fancy_index(self, sim_array_to_fill, hdf_dataset, source_sel):
         """Fill array from a non-contiguous (fancy) index."""
-        id_min, id_max = source_sel[0], source_sel[-1]
-        num_read = id_max - id_min + 1
-        indices_in_read_chunk = source_sel - id_min
 
-        contiguous_hdf_slice = self._get_contiguous_hdf_slice(id_min, id_max)
+        if hdfstream is not None and isinstance(hdf_dataset, hdfstream.RemoteDataset):
+            # Special case for remote files: fancy indexing is implemented by the hdfstream module
+            final_data_to_fill = hdf_dataset[source_sel,...]
+        else:
+            id_min, id_max = source_sel[0], source_sel[-1]
+            num_read = id_max - id_min + 1
+            indices_in_read_chunk = source_sel - id_min
 
-        data_chunk_from_hdf = hdf_dataset[contiguous_hdf_slice]
-        data_chunk_from_hdf = data_chunk_from_hdf.reshape(num_read, *sim_array_to_fill.shape[1:])
+            contiguous_hdf_slice = self._get_contiguous_hdf_slice(id_min, id_max)
 
-        final_data_to_fill = data_chunk_from_hdf[indices_in_read_chunk]
+            data_chunk_from_hdf = hdf_dataset[contiguous_hdf_slice]
+            data_chunk_from_hdf = data_chunk_from_hdf.reshape(num_read, *sim_array_to_fill.shape[1:])
+
+            final_data_to_fill = data_chunk_from_hdf[indices_in_read_chunk]
 
         if sim_array_to_fill.shape == final_data_to_fill.shape:
             sim_array_to_fill[:] = final_data_to_fill

--- a/pynbody/snapshot/gadgethdf.py
+++ b/pynbody/snapshot/gadgethdf.py
@@ -198,7 +198,7 @@ class _HDFFileIterator:
         self._hdf_file_iterator = hdf_file_iterator
         self.current_hdf_file = None
         self.file_index = -1
-        self.particle_offset = 0 
+        self.particle_offset = 0
         self.select_file(0)
 
     def select_file(self, offset):
@@ -214,7 +214,7 @@ class _HDFArrayFiller:
     """A helper class to fill a pynbody array from an HDF5 dataset."""
 
     def __init__(self, sim_array_to_fill = None, hdf_dataset = None):
-        
+
         # default element size for simulation arrays
         self.sim_element_size = 1 if sim_array_to_fill is None else self._get_element_size(sim_array_to_fill)
         self.file_element_size = 1 if hdf_dataset is None else self._get_element_size(hdf_dataset)
@@ -224,7 +224,7 @@ class _HDFArrayFiller:
         """Update the element size for the simulation array."""
         self.sim_element_size = self._get_element_size(sim_array_to_fill)
         self._update_scaling_factor()
-    
+
     def _update_file_element_size(self, hdf_dataset):
         """Update the element size for the HDF5 dataset."""
         self.file_element_size = self._get_element_size(hdf_dataset)
@@ -273,23 +273,32 @@ class _HDFArrayFiller:
                 return slice(source_sel[0], source_sel[-1] + 1)
         return source_sel
 
+    def _get_data_to_fill_local(self, sim_array_to_fill, hdf_dataset, source_sel):
+        """Read the selected elements from a local HDF5 file"""
+        id_min, id_max = source_sel[0], source_sel[-1]
+        num_read = id_max - id_min + 1
+        indices_in_read_chunk = source_sel - id_min
+        contiguous_hdf_slice = self._get_contiguous_hdf_slice(id_min, id_max)
+        data_chunk_from_hdf = hdf_dataset[contiguous_hdf_slice]
+        data_chunk_from_hdf = data_chunk_from_hdf.reshape(num_read, *sim_array_to_fill.shape[1:])
+        return data_chunk_from_hdf[indices_in_read_chunk]
+
+    def _get_data_to_fill_remote(self, sim_array_to_fill, hdf_dataset, source_sel):
+        """Read the selected elements from a remote file using the hdfstream module"""
+        if self.need_rescale:
+            flat_index = (self.scale_factor * np.asarray(source_sel)[:,None] + np.arange(self.scale_factor, dtype=int)).flatten()
+            flat_data = hdf_dataset[flat_index]
+            final_data_to_fill = flat_data.reshape((len(source_sel),self.scaling_factor))
+        else:
+            final_data_to_fill = hdf_dataset[source_sel,...]
+        return final_data_to_fill
+
     def _fill_from_fancy_index(self, sim_array_to_fill, hdf_dataset, source_sel):
         """Fill array from a non-contiguous (fancy) index."""
-
         if hdfstream is not None and isinstance(hdf_dataset, hdfstream.RemoteDataset):
-            # Special case for remote files: fancy indexing is implemented by the hdfstream module
-            final_data_to_fill = hdf_dataset[source_sel,...]
+            final_data_to_fill = self._get_data_to_fill_remote(sim_array_to_fill, hdf_dataset, source_sel)
         else:
-            id_min, id_max = source_sel[0], source_sel[-1]
-            num_read = id_max - id_min + 1
-            indices_in_read_chunk = source_sel - id_min
-
-            contiguous_hdf_slice = self._get_contiguous_hdf_slice(id_min, id_max)
-
-            data_chunk_from_hdf = hdf_dataset[contiguous_hdf_slice]
-            data_chunk_from_hdf = data_chunk_from_hdf.reshape(num_read, *sim_array_to_fill.shape[1:])
-
-            final_data_to_fill = data_chunk_from_hdf[indices_in_read_chunk]
+            final_data_to_fill = self._get_data_to_fill_local(sim_array_to_fill, hdf_dataset, source_sel)
 
         if sim_array_to_fill.shape == final_data_to_fill.shape:
             sim_array_to_fill[:] = final_data_to_fill
@@ -298,7 +307,7 @@ class _HDFArrayFiller:
 
     def _fill_from_slice(self, sim_array_to_fill, hdf_dataset, source_sel):
         """Fill array from a contiguous slice."""
-        
+
         if self.need_rescale:
             source_sel = self._get_contiguous_hdf_slice(source_sel.start, source_sel.stop - 1)
 

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -13,39 +13,6 @@ from .gadgethdf import GadgetHDFSnap, _GadgetHdfMultiFileManager
 
 class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
 
-    def __init__(self, filename: pathlib.Path, take_cells, take_region, mode='r'):
-        self._take_cells = take_cells
-
-        if take_cells is not None and take_region is not None:
-            raise ValueError("Either take_cells or take_region must be specified, not both")
-
-        if take_cells is not None or take_region is not None:
-            # we need to avoid loading a VDS file, as it won't have the info needed to make our own VDS
-            # pointers to the right cells
-            try:
-                with h5py.File(filename, mode='r') as f:
-                    if f['Header'].attrs['Virtual'][0] == 1 and filename.suffix == '.hdf5':
-                        # if we simply strip off .hdf5, GadgetHDFSnap will find the underlying files (hopefully..)
-                        filename = filename.with_suffix('')
-                    # it's not a virtual file anyway, so we're ok
-            except FileNotFoundError:
-                pass # perfect, this is either going to be pieced together by pynbody, or it'll fail anyway
-        super().__init__(filename, mode)
-
-        if take_region is not None:
-            # convert take to take_cells
-            take_cells = self._identify_cells_to_take(take_region)
-
-        # hopefully the shenanigans above mean we don't end up with a VDS, but just in case we do, check again:
-        if self.is_virtual() and take_cells is not None:
-            raise ValueError("Can't take a subset of cells from a VDS-based HDF5 file pointing to multiple underlying files")
-
-        self._make_hdf_vfile(take_cells)
-
-    def _identify_cells_to_take(self, take):
-        centres = self[0]['Cells/Centres'][:]
-        return np.where(take.cubic_cell_intersection(centres))[0]
-
     def get_unit_attrs(self):
         return self[0].parent['InternalCodeUnits'].attrs
 
@@ -58,94 +25,8 @@ class SwiftMultiFileManager(_GadgetHdfMultiFileManager):
         except KeyError:
             return False
 
-    def iter_particle_groups_with_name(self, hdf_family_name):
-        if hdf_family_name in self._hdf_vfile:
-            if self._size_from_hdf5_key in self._hdf_vfile[hdf_family_name]:
-                yield self._hdf_vfile[hdf_family_name]
-
     def _all_group_names(self):
         return self[0]['Cells/Counts'].keys()
-
-    def _make_hdf_vfile(self, take_cells):
-        temp_dir_path = tempfile.mkdtemp()
-        tmpfile_path = os.path.join(temp_dir_path, "nofile.hdf5")
-        with h5py.File(name=tmpfile_path, mode='w') as hdf_vfile:
-            # ideally one would simply use  backing_store=False, to File but then there doesn't seem to be a way
-            # to actually use the file (the VDS views just returns zeros).
-            # Instead we write then re-read it, which presumably carries minimal overhead but is a bit ugly.
-
-            for group_name in self._all_group_names():
-
-                if take_cells is None:
-                    source_groups, source_slices = self._generate_groups_and_slices_for_full_file(group_name)
-                else:
-                    source_groups, source_slices = self._generate_groups_and_slices_from_cells(group_name,
-                                                                                               take_cells)
-
-                target_group = hdf_vfile.create_group(group_name)
-                self._make_hdf_group_with_slicing(source_groups, source_slices, target_group)
-
-        self._hdf_vfile = h5py.File(name=tmpfile_path, mode='r')
-        self._finalizer = weakref.finalize(self, self._finalize, self._hdf_vfile, temp_dir_path)
-
-    @classmethod
-    def _finalize(cls, hdf_vfile, temp_dir_path):
-        try:
-           hdf_vfile.close()
-        except Exception:
-            pass
-
-        shutil.rmtree(temp_dir_path)
-
-    def _generate_groups_and_slices_for_full_file(self, group_name):
-        source_groups = [hdf_file[group_name] for hdf_file in self]
-        source_lens = [len(f[group_name][self._size_from_hdf5_key]) for f in self]
-        source_slices = [[slice(0, l)] for l in source_lens]
-        return source_groups, source_slices
-
-    def _generate_groups_and_slices_from_cells(self, group_name, take_cells):
-        # we get the cell info from the first file, and assume it's consistent between files
-        offsets = self[0]['Cells']['OffsetsInFile'][group_name]
-        lens = self[0]['Cells']['Counts'][group_name]
-        file_responsible = self[0]['Cells']['Files'][group_name]
-
-        # First, make a map from the file ID to the slices to be taken from that file
-        file_id_to_slices_map = {}
-        for cell in take_cells:
-            if file_responsible[cell] not in file_id_to_slices_map:
-                file_id_to_slices_map[file_responsible[cell]] = []
-            sl = slice(offsets[cell], offsets[cell] + lens[cell])
-            file_id_to_slices_map[file_responsible[cell]].append(sl)
-
-        # Now, reformat everything into the format expected by _make_hdf_group_with_slicing
-        source_slices = []
-        source_groups = []
-
-        for file_id in sorted(list(file_id_to_slices_map)):
-            source_groups.append(self[file_id][group_name])
-            source_slices.append(sorted(file_id_to_slices_map[file_id]))
-
-        return source_groups, source_slices
-
-    def _make_hdf_group_with_slicing(self, source_groups, source_slices, target_group):
-        total_len = 0
-        for take_slices in source_slices:
-            for s in take_slices:
-                assert s.step is None
-                total_len += s.stop - s.start
-
-        for array_name in source_groups[0]:
-            offset = 0
-            target_dims = (total_len,) + source_groups[0][array_name].shape[1:]
-            layout = h5py.VirtualLayout(shape=target_dims, dtype=source_groups[0][array_name].dtype)
-
-            for source_group, take_slices in zip(source_groups, source_slices):
-                source = h5py.VirtualSource(source_group[array_name])
-                for s in take_slices:
-                    layout[slice(offset, offset+s.stop-s.start)] = source[s]
-                    offset += s.stop-s.start
-
-            target_group.create_virtual_dataset(array_name, layout)
 
 
 class ExtractScalarWrapper:
@@ -170,14 +51,61 @@ class SwiftSnap(GadgetHDFSnap):
 
     _namemapper_config_section = 'swift-name-mapping'
 
-    def __init__(self, filename, take_swift_cells=None, take_region=None):
-        self._take_swift_cells = take_swift_cells
-        self._take_region = take_region
-        super().__init__(filename)
 
+    def _get_take_parameter(self, **kwargs):
+        if len({"take", "take_swift_region", "take_swift_cells"} & kwargs.keys()) > 1:
+            raise ValueError("Can only specify one of take, take_cells or take_region")
+        if "take" in kwargs:
+            return kwargs.pop("take")
+        elif "take_swift_cells" in kwargs:
+            return self._take_from_cells(kwargs.pop("take_swift_cells"))
+        elif "take_region" in kwargs:
+            return self._take_from_region(kwargs.pop("take_region"))
+        else:
+            return None
 
-    def _init_hdf_filemanager(self, filename):
-        self._hdf_files = self._multifile_manager_class(filename, self._take_swift_cells, self._take_region)
+    def _take_from_cells(self, take_cells):
+        if take_cells is None:
+            return None
+
+        # Check if we're reading one file from a multi file snapshot
+        snap = self._hdf_files[0]
+        header = ExtractScalarWrapper(snap["Header"].attrs)
+        nr_files = header["NumFilesPerSnapshot"]
+        if len(self._hdf_files) < nr_files:
+            raise NotImplementedError("Can't use take_cells or take_region on a single sub-file")
+
+        # Validate the input cell index array
+        take_cells = np.unique(np.asarray(take_cells, dtype=int))
+        nr_cells = snap["Cells/Centres"].shape[0]
+        if np.any(take_cells < 0) or np.any(take_cells >= nr_cells):
+            raise ValueError("SWIFT cell index is out of range!")
+
+        # Compute particle indices corresponding to the selected cells
+        take = []
+        ptype_offset = 0
+        for family in self._families_ordered():
+            for name in self._family_to_group_map[family]:
+                cell_file_index = snap["Cells/Files"][name][...]
+                cell_file_offset = snap["Cells/OffsetsInFile"][name][...]
+                particles_per_cell = snap["Cells/Counts"][name][...]
+                particles_per_file = np.bincount(cell_file_index, weights=particles_per_cell, minlength=nr_files)
+                offset_to_file = np.cumsum(particles_per_file, dtype=np.int64) - particles_per_file
+                offset_to_cell = ptype_offset + offset_to_file[cell_file_index] + cell_file_offset
+                cell_offsets_to_take = offset_to_cell[take_cells]
+                cell_counts_to_take = particles_per_cell[take_cells]
+                order = np.argsort(cell_offsets_to_take)
+                for cell_count, cell_offset in zip(cell_counts_to_take[order], cell_offsets_to_take[order]):
+                    take.append(np.arange(cell_offset, cell_offset+cell_count, dtype=np.int64))
+                ptype_offset += np.sum(particles_per_cell, dtype=np.int64)
+        return np.concatenate(take)
+
+    def _take_from_region(self, take_region):
+        if take_region is None:
+            return None
+        centres = self._hdf_files[0]['Cells/Centres'][:]
+        take_cells = np.where(take_region.cubic_cell_intersection(centres))[0]
+        return self._take_from_cells(take_cells)
 
     def _is_cosmological(self):
         cosmo = ExtractScalarWrapper(self._hdf_files[0]['Cosmology'].attrs)

--- a/pynbody/snapshot/swift.py
+++ b/pynbody/snapshot/swift.py
@@ -1,10 +1,3 @@
-import os
-import pathlib
-import shutil
-import tempfile
-import weakref
-
-import h5py
 import numpy as np
 
 from .. import halo, units, util

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+try:
+    import hdfstream
+except ImportError:
+    hdfstream = None
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--hdfstream-server", type=str, default=None, help="hdfstream server URL for the test"
+    )
+    parser.addoption(
+        "--no-verify-cert", action="store_true", default=False, help="Don't verify SSL certificates if set"
+    )
+    parser.addoption(
+        "--testdata-prefix", type=str, default="/", help="Location of pynbody testdata dir on the server"
+    )
+
+@pytest.fixture(scope="module", params=[False, True])
+def load_kwargs(request):
+    if request.param:
+        # This is a remote file test. Get the server URL.
+        server = request.config.getoption("--hdfstream-server")
+        if server is None:
+            pytest.skip("hdfstream server URL not specified")
+        # Check we have the client module
+        if hdfstream is None:
+            pytest.skip("hdfstream client module not available")
+        # We might not have a valid certificate in development builds of the server
+        hdfstream.verify_cert(not request.config.getoption("--no-verify-cert"))
+        # Pynbody test data might be in a subdirectory on the server
+        prefix = request.config.getoption("--testdata-prefix")
+        # Open and return the remote directory
+        return {"remote_dir" : hdfstream.open(server, prefix)}
+    else:
+        # This is a local file test, so no extra args are needed
+        return {}

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -19,12 +19,12 @@ def get_data():
     pynbody.test_utils.ensure_test_data_available("swift_isolated")
     pynbody.test_utils.ensure_test_data_available("swift_planetary")
 
-def test_load_identifies_swift():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
-    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
+def test_load_identifies_swift(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
+    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
 
-def test_swift_properties():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_properties(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     assert np.allclose(f.properties['a'], 0.38234515)
     assert np.allclose(f.properties['z'], 1.61543791)
@@ -38,15 +38,15 @@ def test_swift_properties():
     # units, which is inconsistent with what swift actually outputs.
     assert np.allclose(f.properties['time'].in_units("s"), 1.28661456e17)
 
-def test_swift_noncosmological():
-    f = pynbody.load("testdata/SWIFT/isolated_0008.hdf5")
-    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
+def test_swift_noncosmological(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/isolated_0008.hdf5", **load_kwargs)
+    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
     assert (f['pos'].units / pynbody.units.Unit("cm")).is_dimensionless()
 
 
 
-def test_swift_arrays():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_arrays(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     assert np.allclose(f.dm['pos'].units.ratio("Mpc a", **f.conversion_context()), 1.0)
     assert np.allclose(f.dm['vel'].units.ratio("km s^-1", **f.conversion_context()), 1.0)
     # the reason the following isn't exactly 1.0 is because our solar mass is slightly different to swift's
@@ -77,28 +77,28 @@ def _assert_multifile_contents_is_sensible(f):
                                                        [83.46050257, 20.91647755, 116.546989],
                                                        [125.83232028, 49.9732396, 72.2264199]]))
 
-def test_swift_multifile_with_vds():
-    f = pynbody.load("testdata/SWIFT/multifile_with_vds/snap_0000.hdf5")
-    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
+def test_swift_multifile_with_vds(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/multifile_with_vds/snap_0000.hdf5", **load_kwargs)
+    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
     assert len(f._hdf_files) == 1
     assert f._hdf_files.is_virtual()
     _assert_multifile_contents_is_sensible(f)
 
 
-def test_swift_multifile_without_vds():
-    f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000")
-    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
+def test_swift_multifile_without_vds(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000", **load_kwargs)
+    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
     assert len(f._hdf_files) == 10
     assert not f._hdf_files.is_virtual()
     _assert_multifile_contents_is_sensible(f)
 
-def test_swift_singlefile_is_not_vds():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_singlefile_is_not_vds(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     assert not f._hdf_files.is_virtual()
 
-def test_swift_singlefile_partial_loading():
+def test_swift_singlefile_partial_loading(load_kwargs):
     f = pynbody.load("testdata/SWIFT/snap_0150.hdf5",
-                     take_swift_cells=[5,15,20,25])
+                     take_swift_cells=[5,15,20,25], **load_kwargs)
     assert len(f.dm) == 1849
     assert len(f.gas) == 1882
     assert (f.dm['iord'][::100] == [ 16468,   9172,  41176,  49874,   9342,  10234,  33908,  25852,
@@ -108,9 +108,9 @@ def test_swift_singlefile_partial_loading():
                                      26367,  2503, 26825, 10827, 59463, 26703, 51909, 27927, 12057,
                                      36761]).all()
 
-def test_swift_multifile_partial_loading():
+def test_swift_multifile_partial_loading(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                     take_swift_cells=[0,5,20,200])
+                     take_swift_cells=[0,5,20,200], **load_kwargs)
 
     assert len(f) == 2048
 
@@ -137,22 +137,22 @@ def test_swift_multifile_partial_loading():
                           [ 16.59894837,  36.67247821,  85.82433427],
                           [  9.79404938,  52.28051827,  81.30710868]])
 
-def test_swift_multifile_partial_loading_order_insensitive():
+def test_swift_multifile_partial_loading_order_insensitive(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                     take_swift_cells=[0, 5, 20, 200])
+                     take_swift_cells=[0, 5, 20, 200], **load_kwargs)
     f2 = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                     take_swift_cells=[0, 5, 20, 200][::-1])
+                     take_swift_cells=[0, 5, 20, 200][::-1], **load_kwargs)
     assert (f['iord'] == f2['iord']).all()
 
-def test_swift_vds_partial_loading():
+def test_swift_vds_partial_loading(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_with_vds/snap_0000.hdf5", # <-- VDS file
-                     take_swift_cells=[0,5,20,200])
+                     take_swift_cells=[0,5,20,200], **load_kwargs)
     f2 = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000",
-                      take_swift_cells=[0, 5, 20, 200][::-1])
+                      take_swift_cells=[0, 5, 20, 200][::-1], **load_kwargs)
     assert (f['iord'] == f2['iord']).all()
 
-def test_swift_fof_groups():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_fof_groups(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     h = f.halos(priority = ['HaloNumberCatalogue'])
 
     with raises(KeyError):
@@ -164,26 +164,26 @@ def test_swift_fof_groups():
 
     assert len(h) < 1000
 
-def test_swift_dtypes():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_dtypes(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
     assert np.issubdtype(f['iord'].dtype, np.integer)
     assert np.issubdtype(f['pos'].dtype, np.floating)
 
 @pytest.mark.parametrize('test_region',
                          [pynbody.filt.Sphere(50., (50., 50., 50.)),
                          pynbody.filt.Cuboid(-20.0)]) # note the cuboid test region wraps around the box
-def test_swift_take_geometric_region(test_region):
+def test_swift_take_geometric_region(test_region, load_kwargs):
     f = pynbody.load("testdata/SWIFT/snap_0150.hdf5",
-                     take_region = test_region)
+                     take_region = test_region, **load_kwargs)
 
-    f_full = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+    f_full = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     assert len(f) < len(f_full)
 
     assert np.all(f[test_region]['iord'] == f_full[test_region]['iord'])
 
-def test_swift_scalefactor_in_units():
-    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+def test_swift_scalefactor_in_units(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     # naively, one would assume cm^2 s^-2, but actual units header says 1e10 a^2 cm^2 s^-2
     # So this tests pynbody respects that. Note that we don't give the scalefactor context,
@@ -243,15 +243,15 @@ def swift_snap_with_alternate_mass_naming():
     # clean up
     shutil.rmtree(tempdir)
 
-def test_alternate_mass_file(swift_snap_with_alternate_mass_naming):
+def test_alternate_mass_file(swift_snap_with_alternate_mass_naming, load_kwargs):
     f = pynbody.load(swift_snap_with_alternate_mass_naming)
-    f1 = pynbody.load("testdata/SWIFT/snap_0150.hdf5")
+    f1 = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
 
     assert np.allclose(f['mass'], f1['mass'])
 
-def test_load_planetary():
-    f = pynbody.load("testdata/SWIFT/planetary.hdf5")
-    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
+def test_load_planetary(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/planetary.hdf5", **load_kwargs)
+    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
     assert len(f) == 1000
     assert len(f.gas) == 1000
 
@@ -268,8 +268,8 @@ def test_load_planetary():
 
 
 
-def test_planetary_physical_units():
-    f = pynbody.load("testdata/SWIFT/planetary.hdf5")
+def test_planetary_physical_units(load_kwargs):
+    f = pynbody.load("testdata/SWIFT/planetary.hdf5", **load_kwargs)
     f.physical_units('1e3 km')
     npt.assert_allclose(f['pos'][::100], [[ 64.96079021, 468.85991433, 313.24147579],
           [159.25107139, 424.78484083, 381.50705574],

--- a/tests/swift_test.py
+++ b/tests/swift_test.py
@@ -21,7 +21,7 @@ def get_data():
 
 def test_load_identifies_swift(load_kwargs):
     f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
-    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
+    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
 
 def test_swift_properties(load_kwargs):
     f = pynbody.load("testdata/SWIFT/snap_0150.hdf5", **load_kwargs)
@@ -40,7 +40,7 @@ def test_swift_properties(load_kwargs):
 
 def test_swift_noncosmological(load_kwargs):
     f = pynbody.load("testdata/SWIFT/isolated_0008.hdf5", **load_kwargs)
-    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
+    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert (f['pos'].units / pynbody.units.Unit("cm")).is_dimensionless()
 
 
@@ -79,7 +79,7 @@ def _assert_multifile_contents_is_sensible(f):
 
 def test_swift_multifile_with_vds(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_with_vds/snap_0000.hdf5", **load_kwargs)
-    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
+    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert len(f._hdf_files) == 1
     assert f._hdf_files.is_virtual()
     _assert_multifile_contents_is_sensible(f)
@@ -87,7 +87,7 @@ def test_swift_multifile_with_vds(load_kwargs):
 
 def test_swift_multifile_without_vds(load_kwargs):
     f = pynbody.load("testdata/SWIFT/multifile_without_vds/snap_0000", **load_kwargs)
-    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
+    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert len(f._hdf_files) == 10
     assert not f._hdf_files.is_virtual()
     _assert_multifile_contents_is_sensible(f)
@@ -251,7 +251,7 @@ def test_alternate_mass_file(swift_snap_with_alternate_mass_naming, load_kwargs)
 
 def test_load_planetary(load_kwargs):
     f = pynbody.load("testdata/SWIFT/planetary.hdf5", **load_kwargs)
-    assert isinstance(f, pynbody.snapshot.swift.BaseSwiftSnap)
+    assert isinstance(f, pynbody.snapshot.swift.SwiftSnap)
     assert len(f) == 1000
     assert len(f.gas) == 1000
 


### PR DESCRIPTION
This modifies the SwiftSnap class to avoid using temporary virtual files (which are problematic for remote access) and uses the "take" mechanism from the parent GadgetHdfSnap class instead. It also modifies GadgetHdfSnap to access remote files.